### PR TITLE
Better cargo install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Polars CLI
 
+## 🚀 Get started
+
+```bash
+cargo +nightly install polars-cli
+```
+
+Prerequisites
+1. `rustup`: which provides the `cargo` executable. You can get it from the [official website](https://rustup.rs/).
+2. `rustup install nightly` - The `nightly` version of rust, since some of our dependencies use unstable features.
+
+
 ## CLI
 
 **Build from source**


### PR DESCRIPTION
The current README.md file only shows you how to install from source. This PR adds instructions to install without cloning the repo.